### PR TITLE
Reduce memory allocations

### DIFF
--- a/pymavlink/generator/java/lib/Messages/MAVLinkPayload.java
+++ b/pymavlink/generator/java/lib/Messages/MAVLinkPayload.java
@@ -21,13 +21,12 @@ public class MAVLinkPayload {
 
     private static final long UNSIGNED_LONG_MIN_VALUE = 0;
 
-    public static final int MAX_PAYLOAD_SIZE = 512;
-    
     public final ByteBuffer payload;
     public int index;
 
-    public MAVLinkPayload() {
-        payload = ByteBuffer.allocate(MAX_PAYLOAD_SIZE);
+    public MAVLinkPayload(int payloadSize) {
+        //Payload size should be less than 512.
+        payload = ByteBuffer.allocate(payloadSize);
     }
 
     public ByteBuffer getData() {

--- a/pymavlink/generator/java/lib/Parser.java
+++ b/pymavlink/generator/java/lib/Parser.java
@@ -20,7 +20,7 @@ public class Parser {
 
     MAV_states state = MAV_states.MAVLINK_PARSE_STATE_UNINIT;
 
-    static boolean msg_received;
+    private boolean msg_received;
 
     public MAVLinkStats stats = new MAVLinkStats();
     private MAVLinkPacket m;
@@ -43,7 +43,6 @@ public class Parser {
 
             if (c == MAVLinkPacket.MAVLINK_STX) {
                 state = MAV_states.MAVLINK_PARSE_STATE_GOT_STX;
-                m = new MAVLinkPacket();
             }
             break;
 
@@ -52,7 +51,7 @@ public class Parser {
                 msg_received = false;
                 state = MAV_states.MAVLINK_PARSE_STATE_IDLE;
             } else {
-                m.len = c;
+                m = new MAVLinkPacket(c);
                 state = MAV_states.MAVLINK_PARSE_STATE_GOT_LENGTH;
             }
             break;

--- a/pymavlink/generator/mavgen_java.py
+++ b/pymavlink/generator/mavgen_java.py
@@ -161,7 +161,6 @@ public class msg_${name_lower} extends MAVLinkMessage{
     */
     public MAVLinkPacket pack(){
         MAVLinkPacket packet = new MAVLinkPacket(MAVLINK_MSG_LENGTH);
-        packet.len = MAVLINK_MSG_LENGTH;
         packet.sysid = 255;
         packet.compid = 190;
         packet.msgid = MAVLINK_MSG_ID_${name};

--- a/pymavlink/generator/mavgen_java.py
+++ b/pymavlink/generator/mavgen_java.py
@@ -160,7 +160,7 @@ public class msg_${name_lower} extends MAVLinkMessage{
     * @return
     */
     public MAVLinkPacket pack(){
-        MAVLinkPacket packet = new MAVLinkPacket();
+        MAVLinkPacket packet = new MAVLinkPacket(MAVLINK_MSG_LENGTH);
         packet.len = MAVLINK_MSG_LENGTH;
         packet.sysid = 255;
         packet.compid = 190;
@@ -360,7 +360,7 @@ public class MAVLinkPacket implements Serializable {
     /**
     * Message length. NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
     */
-    public int len;
+    public final int len;
 
     /**
     * Message sequence
@@ -398,18 +398,16 @@ public class MAVLinkPacket implements Serializable {
     */
     public CRC crc;
 
-    public MAVLinkPacket(){
-        payload = new MAVLinkPayload();
+    public MAVLinkPacket(int payloadLength){
+        this.len = payloadLength;
+        payload = new MAVLinkPayload(payloadLength);
     }
 
     /**
     * Check if the size of the Payload is equal to the "len" byte
     */
     public boolean payloadIsFilled() {
-        if (payload.size() >= MAVLinkPayload.MAX_PAYLOAD_SIZE-1) {
-            return true;
-        }
-        return (payload.size() == len);
+        return payload.size() >= len;
     }
 
     /**
@@ -431,7 +429,8 @@ public class MAVLinkPacket implements Serializable {
 
         payload.resetIndex();
 
-        for (int i = 0; i < payload.size(); i++) {
+        final int payloadSize = payload.size();
+        for (int i = 0; i < payloadSize; i++) {
             crc.update_checksum(payload.getByte());
         }
         crc.finish_checksum(msgid);
@@ -453,7 +452,8 @@ public class MAVLinkPacket implements Serializable {
         buffer[i++] = (byte) compid;
         buffer[i++] = (byte) msgid;
 
-        for (int j = 0; j < payload.size(); j++) {
+        final int payloadSize = payload.size();
+        for (int j = 0; j < payloadSize; j++) {
             buffer[i++] = payload.payload.get(j);
         }
 


### PR DESCRIPTION
mavlink payload size is now specified at construction time to avoid spurious buffer allocation.
